### PR TITLE
Wallet fixes

### DIFF
--- a/src/components/Header/header.tsx
+++ b/src/components/Header/header.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useContext, useState, useEffect } from "react";
 import { FaEthereum, FaCircle } from "react-icons/fa";
 import { useRouter } from "next/router";
 
@@ -12,6 +12,12 @@ function Header() {
   const {walletAddress, getWeb3Provider, clearWallet, web3Provider} = useContext(WalletContext);
   const router = useRouter();
 
+  useEffect(() => {
+    getWalletBalance()
+  }, [])
+
+  const [balance,setBalance] = useState('0');
+
   const navigateToAdPage = () => {
     router.push("/adMarketPlace");
   };
@@ -19,12 +25,13 @@ function Header() {
   const navigateToHottestSongPage = () => {
     router.push("/");
   };
-  // useRouter();
 
-  const walletBalance = async()=>{
-    const response = await web3Provider?.getSigner().getBalance();
-    const balance = utils.formatEther(response) 
-    return balance
+  const getWalletBalance = async()=>{
+    const response = await web3Provider?.getSigner().getBalance() || 0;
+    const balance = utils.formatEther(response)
+    const formatedBalance = Number(balance).toFixed(4)
+    setBalance(String(formatedBalance))
+
   }
 
   return (
@@ -77,7 +84,7 @@ function Header() {
               onClick={clearWallet}
               className="flex flex-row items-center px-4 py-1 border bg-white text-black font-medium text-base leading-tight uppercase rounded-full my-3"
             >
-              <span>0 MATIC</span>
+              <span>{`${balance} MATIC`}</span>
               <span className="flex flex-row align-center bg-gray-100 rounded-full p-1 ml-1">
                 <FaCircle className=" text-[#15ae5c] mr-1 w-5 h-5" />
                 {walletAddress.substring(0, 4)}...

--- a/src/components/Header/header.tsx
+++ b/src/components/Header/header.tsx
@@ -60,7 +60,8 @@ function Header() {
             />
             <span className="flex ml-1 text-base">Mumbai</span>
           </div>
-          {!walletAddress ? (
+
+          {!web3Provider ? (
             <button
               onClick={getWeb3Provider}
               className="flex flex-row items-center px-4 py-1 border bg-white text-black font-medium text-base leading-tight uppercase rounded-full my-3 mr-4"

--- a/src/components/Header/header.tsx
+++ b/src/components/Header/header.tsx
@@ -1,10 +1,15 @@
-import React, { useContext, useRef } from "react";
+import React, { useContext } from "react";
 import { FaEthereum, FaCircle } from "react-icons/fa";
 import { useRouter } from "next/router";
+
+// context imports
 import { WalletContext } from "../../contexts/WalletContext";
 
+// ethers imports
+import {utils} from 'ethers'
+
 function Header() {
-  const walletContext = useContext(WalletContext);
+  const {walletAddress, getWeb3Provider, clearWallet, web3Provider} = useContext(WalletContext);
   const router = useRouter();
 
   const navigateToAdPage = () => {
@@ -14,7 +19,13 @@ function Header() {
   const navigateToHottestSongPage = () => {
     router.push("/");
   };
-  useRouter();
+  // useRouter();
+
+  const walletBalance = async()=>{
+    const response = await web3Provider?.getSigner().getBalance();
+    const balance = utils.formatEther(response) 
+    return balance
+  }
 
   return (
     <>
@@ -54,23 +65,23 @@ function Header() {
             />
             <span className="flex ml-1 text-base">Mumbai</span>
           </div>
-          {!walletContext.walletAddress ? (
+          {!walletAddress ? (
             <button
-              onClick={walletContext.getWeb3Provider}
+              onClick={getWeb3Provider}
               className="flex flex-row items-center px-4 py-1 border bg-white text-black font-medium text-base leading-tight uppercase rounded-full my-3 mr-4"
             >
               Connect
             </button>
           ) : (
             <button
-              onClick={walletContext.clearWallet}
+              onClick={clearWallet}
               className="flex flex-row items-center px-4 py-1 border bg-white text-black font-medium text-base leading-tight uppercase rounded-full my-3"
             >
               <span>0 MATIC</span>
               <span className="flex flex-row align-center bg-gray-100 rounded-full p-1 ml-1">
                 <FaCircle className=" text-[#15ae5c] mr-1 w-5 h-5" />
-                {walletContext.walletAddress.substring(0, 4)}...
-                {walletContext.walletAddress.substring(-4, 4)}
+                {walletAddress.substring(0, 4)}...
+                {walletAddress.substring(-4, 4)}
               </span>
             </button>
           )}

--- a/src/components/Header/header.tsx
+++ b/src/components/Header/header.tsx
@@ -9,14 +9,9 @@ import { WalletContext } from "../../contexts/WalletContext";
 import {utils} from 'ethers'
 
 function Header() {
-  const {walletAddress, getWeb3Provider, clearWallet, web3Provider} = useContext(WalletContext);
+  const {walletAddress, walletBalance, getWeb3Provider, clearWallet, web3Provider} = useContext(WalletContext);
   const router = useRouter();
 
-  useEffect(() => {
-    getWalletBalance()
-  }, [])
-
-  const [balance,setBalance] = useState('0');
 
   const navigateToAdPage = () => {
     router.push("/adMarketPlace");
@@ -26,13 +21,6 @@ function Header() {
     router.push("/");
   };
 
-  const getWalletBalance = async()=>{
-    const response = await web3Provider?.getSigner().getBalance() || 0;
-    const balance = utils.formatEther(response)
-    const formatedBalance = Number(balance).toFixed(4)
-    setBalance(String(formatedBalance))
-
-  }
 
   return (
     <>
@@ -84,7 +72,7 @@ function Header() {
               onClick={clearWallet}
               className="flex flex-row items-center px-4 py-1 border bg-white text-black font-medium text-base leading-tight uppercase rounded-full my-3"
             >
-              <span>{`${balance} MATIC`}</span>
+              <span>{`${walletBalance} MATIC`}</span>
               <span className="flex flex-row align-center bg-gray-100 rounded-full p-1 ml-1">
                 <FaCircle className=" text-[#15ae5c] mr-1 w-5 h-5" />
                 {walletAddress.substring(0, 4)}...

--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -57,7 +57,7 @@ export function WalletProvider(props: React.PropsWithChildren) {
   const formatBalance = (balance:BigNumber)=>{
     const etherFormat = utils.formatEther(balance)
     const formatedBalance = Number(etherFormat).toFixed(4)
-    return String(formatedBalance);
+    return formatedBalance;
   }
 
   useEffect(() => {

--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -3,12 +3,14 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import Web3Modal from "web3modal";
 import WalletConnectProvider from "@walletconnect/web3-provider";
 import { Chain } from "../env";
+import {utils,BigNumber} from 'ethers'
 
 type WalletContextType = {
   web3Provider: providers.Web3Provider | undefined;
   getWeb3Provider: () => Promise<providers.Web3Provider>;
   clearWallet: () => void;
   walletAddress: string;
+  walletBalance: string;
 };
 export let WalletContext: React.Context<WalletContextType>;
 
@@ -32,15 +34,30 @@ if (typeof window !== "undefined") {
 }
 
 export function WalletProvider(props: React.PropsWithChildren) {
+
   const [provider, setProvider] = useState<providers.Web3Provider>();
   const [walletAddress, setWalletAddress] = useState("");
+  const [walletBalance, setWalletBalance] = useState("");
+
   const getWeb3Provider = useCallback(async () => {
     const wallet = await web3Modal.connect();
     const provider = new providers.Web3Provider(wallet);
-    setWalletAddress(await provider.getSigner().getAddress());
+
+    const signer = provider.getSigner();
+    const walletAddress = await signer.getAddress()
+    const walletBalance =  await signer.getBalance() || 0
+    const formattedBalance = formatBalance(walletBalance)
+    setWalletAddress(walletAddress);
+    setWalletBalance(formattedBalance);
     setProvider(provider);
     return provider;
-  }, []);
+  }, []); 
+
+  const formatBalance = (balance:BigNumber)=>{
+    const etherFormat = utils.formatEther(balance)
+    const formatedBalance = Number(etherFormat).toFixed(4)
+    return String(formatedBalance);
+  }
 
   useEffect(() => {
     if (web3Modal.cachedProvider) {
@@ -63,8 +80,9 @@ export function WalletProvider(props: React.PropsWithChildren) {
       clearWallet,
       getWeb3Provider,
       walletAddress,
+      walletBalance
     }),
-    [provider, clearWallet, getWeb3Provider, walletAddress]
+    [provider, clearWallet, getWeb3Provider, walletBalance, walletAddress]
   );
 
   WalletContext = React.createContext(value);


### PR DESCRIPTION
Having the entire app consume the wallet context is really a problem because every change to it's state re-renders everything. Just connecting and disconnecting wallet re-renders the songList, same problem with the UX issue we have on the `connect-before-action` PR. I will check it out after i'm done with other issues.